### PR TITLE
Create simple zsh plugin which can be loaded by most major plugin managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ with minimal set up required.
 
 - [Getting started](#getting-started)
   - [Install](#install)
+    - [Manual](#manual)
+    - [Zsh Plugin](#zsh-plugin)
   - [Dependencies](#dependencies)
   - [Setup](#setup)
   - [Migration](#migration)
@@ -92,6 +94,8 @@ with minimal set up required.
 
 ### Install
 
+#### Manual
+
 1. Clone the repository (change ~/.dotbare to the location of your preference)
 
    ```sh
@@ -111,6 +115,12 @@ with minimal set up required.
    ```sh
    alias dotbare="$HOME/.dotbare/dotbare"
    ```
+
+#### Zsh plugin
+
+##### Zinit
+
+add `zinit light kazhala/dotbare` to `~/.zshrc`.
 
 ### Dependencies
 

--- a/dotbare.plugin.zsh
+++ b/dotbare.plugin.zsh
@@ -1,0 +1,7 @@
+# Standardized $0 handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+local _path="${0:h}"
+
+if [[ -z "${path[(r)$_path]}" ]]; then
+    path+=( "$_path" )
+fi


### PR DESCRIPTION
This adds a plugin file and adds instructions for installing using https://github.com/zdharma/zinit. It achieves the same thing a manual installation would achieve.

I'd recommend looking into moving dotbare and related helper/scripts into a `bin` directory and adding that to `PATH`, along with adjusting everything to account for that change if necessary. As of now `shellcheck.sh` is available as a command to the user and shouldn't be.