### PR TITLE
relocate shellcheck.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install shellcheck -y
-      - run: ./shellcheck.sh
+      - run: ./tests/shellcheck.sh
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: brew install shellcheck
-      - run: ./shellcheck.sh
+      - run: ./tests/shellcheck.sh
       - run: brew install bats
       - run: ./dotbare finit -u https://github.com/kazhala/dotfiles.git
       - run: bats tests

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,7 @@ phases:
   build:
     commands:
       - echo Checking script compliance
-      - ./shellcheck.sh
+      - ./tests/shellcheck.sh
       - echo Building docker url image ...
       - docker image build --build-arg MIGRATE=url -t kazhala/dotbare:testurl -f tests/Dockerfile .
       - echo Running bats unittest ...

--- a/tests/shellcheck.sh
+++ b/tests/shellcheck.sh
@@ -4,6 +4,9 @@
 
 set -e
 
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${mydir}"/../
+
 scripts=()
 while IFS=  read -r -d $'\0' line; do
     scripts+=("$line")
@@ -12,7 +15,7 @@ done < <(
     dotbare \
     helper/* \
     scripts/* \
-    shellcheck.sh \
+    tests/shellcheck.sh \
     -type f \
     -print0
   )


### PR DESCRIPTION
As noted by @NICHOLAS85, shellcheck.sh should not have been in the PATH along with dotbare executable. This the first step of reordering things.