### PR TITLE
docs: fix typo on setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ it will require you to have bash in the system (You don't need to run bash, just
    ```sh
    dotbare fadd -f
    # or
-   dotbare add [FIELNAME]
+   dotbare add [FILENAME]
 
    # add entire repository like .config directory
    dotbare fadd -d


### PR DESCRIPTION
A quick fix for a typo i've found on the "Setup" section while reading the readme

> `FIELNAME` -> `FILENAME`