### PR TITLE
Fix typo in subcommand description

### DIFF
--- a/dotbare.plugin.zsh
+++ b/dotbare.plugin.zsh
@@ -31,7 +31,7 @@ __dotbare_completion() {
         'finit:init/migrate dotbare'
         'flog:interactive log viewer'
         'freset:reset files/commit'
-        'fstash:stage management'
+        'fstash:stash management'
         'fstat:toggle stage/unstage of files'
         'funtrack:untrack files'
         'fupgrade:update dotbare'

--- a/pkg/completion/zsh/_dotbare
+++ b/pkg/completion/zsh/_dotbare
@@ -26,7 +26,7 @@ _dotbare() {
         'finit:init/migrate dotbare'
         'flog:interactive log viewer'
         'freset:reset files/commit'
-        'fstash:stage management'
+        'fstash:stash management'
         'fstat:toggle stage/unstage of files'
         'funtrack:untrack files'
         'fupgrade:update dotbare'


### PR DESCRIPTION
This PR fixes the typo that shows up when viewing the available sub-commands via auto-completion (how I discovered it).

Great project by the way! I just discovered it today very randomly while trying to set up my bare git repo dotfiles. This package makes things just a tad bit easier!